### PR TITLE
Add Array Clip: rect presets and image array clipping

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -258,6 +258,7 @@
             <div class="tab" data-target="panel-swap" data-hash="swap">Swap</div>
             <div class="tab" data-target="panel-labels" data-hash="labels">Image Labels</div>
             <div class="tab" data-target="panel-border" data-hash="border">Add Border</div>
+            <div class="tab" data-target="panel-array-clip" data-hash="arrayclip">Array Clip</div>
             <div class="tab" data-target="panel-about" data-hash="about">About</div>
         </div>
         <div class="content">
@@ -509,6 +510,55 @@
                 </div>
             </div>
             <!-- Add Border Panel -->
+            <!-- Array Clip Panel -->
+            <div class="panel" id="panel-array-clip">
+                <h4>Format Clip Rect</h4>
+                <p style="color: var(--muted); font-size: 12px; margin: 4px 0 8px;">
+                    Draw rectangles with the Rectangle tool (M), select them, then apply a preset.
+                </p>
+                <div class="grid">
+                    <div class="input-group">
+                        <label>Preset:</label>
+                        <select id="clip-rect-preset" style="flex:1"></select>
+                    </div>
+                </div>
+                <div class="toolbar">
+                    <button class="btn btn-primary" id="format-clip-rect-button">Apply</button>
+                    <button class="btn btn-danger" id="delete-preset-button">Delete</button>
+                </div>
+                <div class="spacer"></div>
+                <h4>Add Preset</h4>
+                <div class="grid">
+                    <div class="input-group">
+                        <label>Color:</label>
+                        <input type="color" id="preset-color" value="#ff0000">
+                    </div>
+                    <div class="input-group">
+                        <label>Width (pt):</label>
+                        <input type="number" id="preset-width" value="1" min="0.1" step="0.1">
+                    </div>
+                </div>
+                <div class="toolbar">
+                    <button class="btn" id="add-preset-button">Add Preset</button>
+                </div>
+
+                <div class="spacer"></div>
+
+                <h4>Array Clip</h4>
+                <p style="color: var(--muted); font-size: 12px; margin: 4px 0 8px;">
+                    Select images + clip rectangles on the first image, then click below.
+                </p>
+                <div class="grid">
+                    <div class="input-group">
+                        <label>Gap (mm):</label>
+                        <input type="number" id="array-clip-gap" value="1" min="0" step="0.1">
+                    </div>
+                </div>
+                <div class="toolbar">
+                    <button class="btn btn-primary" id="array-clip-button">Array Clip</button>
+                </div>
+            </div>
+
             <div class="panel" id="panel-border">
                 <div class="grid">
                     <div class="input-group">
@@ -688,6 +738,7 @@
                 else if (hash === 'labels') target = 'panel-labels';
                 else if (hash === 'size') target = 'panel-size';
                 else if (hash === 'border') target = 'panel-border';
+                else if (hash === 'arrayclip') target = 'panel-array-clip';
                 else if (hash === 'swap') target = 'panel-swap';
                 else if (hash === 'about') target = 'panel-about';
 

--- a/host/index.jsx
+++ b/host/index.jsx
@@ -88,6 +88,49 @@ var addBorderButton = document.querySelector("#add-border-button");
 var borderDashInput = document.querySelector("#border-dash");
 var autoGroupBorderCheckbox = document.querySelector("#auto-group-border");
 
+// Array Clip UI Elements
+var formatClipRectButton = document.querySelector("#format-clip-rect-button");
+var arrayClipButton = document.querySelector("#array-clip-button");
+var arrayClipGapInput = document.querySelector("#array-clip-gap");
+var clipRectPresetSelect = document.querySelector("#clip-rect-preset");
+var presetColorInput = document.querySelector("#preset-color");
+var presetWidthInput = document.querySelector("#preset-width");
+var addPresetButton = document.querySelector("#add-preset-button");
+var deletePresetButton = document.querySelector("#delete-preset-button");
+
+var PRESET_KEY = 'clipRectPresets';
+var defaultPresets = [
+    { name: 'Red 1pt', color: '#ff0000', width: 1 },
+    { name: 'Blue 1pt', color: '#0066ff', width: 1 },
+    { name: 'Green 1pt', color: '#00cc00', width: 1 },
+    { name: 'Black 0.5pt', color: '#000000', width: 0.5 }
+];
+
+function loadPresets() {
+    try {
+        var stored = localStorage.getItem(PRESET_KEY);
+        if (stored) return JSON.parse(stored);
+    } catch (e) { }
+    return defaultPresets.slice();
+}
+
+function savePresets(presets) {
+    localStorage.setItem(PRESET_KEY, JSON.stringify(presets));
+}
+
+function refreshPresetSelect() {
+    var presets = loadPresets();
+    clipRectPresetSelect.innerHTML = '';
+    for (var i = 0; i < presets.length; i++) {
+        var opt = document.createElement('option');
+        opt.value = i;
+        opt.textContent = presets[i].name;
+        clipRectPresetSelect.appendChild(opt);
+    }
+}
+
+refreshPresetSelect();
+
 // Event Listeners
 arrangeButton.addEventListener("click", handleArrange);
 addLabelButton.addEventListener("click", handleAddLabel);
@@ -104,6 +147,11 @@ copySizeButton.addEventListener("click", handleCopySize);
 pasteSizeButton.addEventListener("click", handlePasteSize);
 
 addBorderButton.addEventListener("click", handleAddBorder);
+
+formatClipRectButton.addEventListener("click", handleFormatClipRect);
+arrayClipButton.addEventListener("click", handleArrayClip);
+addPresetButton.addEventListener("click", handleAddPreset);
+deletePresetButton.addEventListener("click", handleDeletePreset);
 
 distributeVerticalButton.addEventListener("click", () => handleDistributeSpacing("vertical"));
 distributeHorizontalButton.addEventListener("click", () => handleDistributeSpacing("horizontal"));
@@ -681,4 +729,64 @@ function handleAddBorder() {
             alert(result);
         }
     });
+}
+
+function handleFormatClipRect() {
+    console.log("Format Clip Rect button clicked");
+    var presets = loadPresets();
+    var idx = parseInt(clipRectPresetSelect.value);
+    if (isNaN(idx) || idx < 0 || idx >= presets.length) {
+        alert("Please select a preset.");
+        return;
+    }
+    var preset = presets[idx];
+    var color = preset.color;
+    var width = preset.width;
+
+    csInterface.evalScript(`$.evalFile("${csInterface.getSystemPath(SystemPath.EXTENSION)}/jsx/arrange.jsx")`);
+    csInterface.evalScript(`formatClipRect("${color}", ${width})`, function (result) {
+        if (result && result.indexOf("Error:") === 0) {
+            alert(result);
+        }
+    });
+}
+
+function handleArrayClip() {
+    console.log("Array Clip button clicked");
+    var gap = parseFloat(arrayClipGapInput.value);
+    if (isNaN(gap) || gap < 0) gap = 1;
+
+    csInterface.evalScript(`$.evalFile("${csInterface.getSystemPath(SystemPath.EXTENSION)}/jsx/arrange.jsx")`);
+    csInterface.evalScript(`arrayClip(${gap})`, function (result) {
+        if (result && result.indexOf("Error:") === 0) {
+            alert(result);
+        }
+    });
+}
+
+function handleAddPreset() {
+    var color = presetColorInput.value;
+    var width = parseFloat(presetWidthInput.value);
+    if (isNaN(width) || width <= 0) {
+        alert("Invalid width value.");
+        return;
+    }
+    var presets = loadPresets();
+    presets.push({ name: color + " " + width + "pt", color: color, width: width });
+    savePresets(presets);
+    refreshPresetSelect();
+    clipRectPresetSelect.value = presets.length - 1;
+}
+
+function handleDeletePreset() {
+    var presets = loadPresets();
+    if (presets.length <= 1) {
+        alert("Cannot delete the last preset.");
+        return;
+    }
+    var idx = parseInt(clipRectPresetSelect.value);
+    if (isNaN(idx) || idx < 0 || idx >= presets.length) return;
+    presets.splice(idx, 1);
+    savePresets(presets);
+    refreshPresetSelect();
 }

--- a/jsx/arrange.jsx
+++ b/jsx/arrange.jsx
@@ -1350,3 +1350,242 @@ function updateLabelOffsets(offsetX, offsetY, sessionId) {
     }
     return "Success";
 }
+
+function formatClipRect(color, strokeWidth) {
+    if (app.documents.length === 0) return "Error: No document open.";
+    var doc = app.activeDocument;
+    var sel = doc.selection;
+    if (!sel || sel.length === 0) return "Error: Please select rectangle shapes.";
+
+    var r = 0, g = 0, b = 0;
+    try {
+        if (typeof color === 'string' && color.charAt(0) === '#' && color.length >= 7) {
+            r = parseInt(color.substr(1, 2), 16) || 0;
+            g = parseInt(color.substr(3, 2), 16) || 0;
+            b = parseInt(color.substr(5, 2), 16) || 0;
+        }
+    } catch (e) {}
+    var rgbColor = new RGBColor();
+    rgbColor.red = r;
+    rgbColor.green = g;
+    rgbColor.blue = b;
+
+    var w = (typeof strokeWidth === 'number') ? strokeWidth : 1;
+
+    var count = 0;
+    for (var i = 0; i < sel.length; i++) {
+        if (sel[i].typename === "PathItem" || sel[i].typename === "CompoundPathItem") {
+            sel[i].filled = false;
+            sel[i].stroked = true;
+            sel[i].strokeColor = rgbColor;
+            sel[i].strokeWidth = w;
+            try { sel[i].strokeDashes = []; } catch (e) {}
+            count++;
+        }
+    }
+    if (count === 0) return "Error: No PathItem shapes found. Draw rectangles with the Rectangle tool (M) first.";
+    return "Success";
+}
+
+function arrayClip(gapMm) {
+    if (app.documents.length === 0) return "Error: No document open.";
+    var doc = app.activeDocument;
+    var sel = doc.selection;
+    if (!sel || sel.length < 2) return "Error: Select at least 1 clip rectangle and 1 image.";
+
+    var images = [];
+    var clipRects = [];
+    for (var i = 0; i < sel.length; i++) {
+        if (sel[i].typename === "PathItem") clipRects.push(sel[i]);
+        else images.push(sel[i]);
+    }
+    if (images.length < 1) return "Error: No images found (non-PathItem objects required).";
+    if (clipRects.length < 1) return "Error: No clip rectangles found (PathItem objects required).";
+
+    var imgInfos = [];
+    for (var i = 0; i < images.length; i++) {
+        imgInfos.push(getVisibleInfo(images[i]));
+    }
+
+    var mode;
+    if (images.length === 1) {
+        mode = "column";
+    } else {
+        var minLeft = Infinity, maxLeft = -Infinity;
+        var minTop = Infinity, maxTop = -Infinity;
+        for (var i = 0; i < imgInfos.length; i++) {
+            if (imgInfos[i].left < minLeft) minLeft = imgInfos[i].left;
+            if (imgInfos[i].left > maxLeft) maxLeft = imgInfos[i].left;
+            if (imgInfos[i].top < minTop) minTop = imgInfos[i].top;
+            if (imgInfos[i].top > maxTop) maxTop = imgInfos[i].top;
+        }
+        mode = (maxTop - minTop > maxLeft - minLeft) ? "column" : "row";
+    }
+
+    var indices = [];
+    for (var i = 0; i < images.length; i++) indices.push(i);
+    if (mode === "column") {
+        indices.sort(function (a, b) { return imgInfos[b].top - imgInfos[a].top; });
+    } else {
+        indices.sort(function (a, b) { return imgInfos[a].left - imgInfos[b].left; });
+    }
+    var sortedImages = [], sortedInfos = [];
+    for (var i = 0; i < indices.length; i++) {
+        sortedImages.push(images[indices[i]]);
+        sortedInfos.push(imgInfos[indices[i]]);
+    }
+
+    var refW = sortedInfos[0].width, refH = sortedInfos[0].height;
+    for (var i = 1; i < sortedInfos.length; i++) {
+        if (Math.abs(sortedInfos[i].width - refW) > 1 || Math.abs(sortedInfos[i].height - refH) > 1) {
+            return "Error: All images must be the same size.";
+        }
+    }
+
+    var firstInfo = sortedInfos[0];
+    var overlappingRects = [];
+    for (var i = 0; i < clipRects.length; i++) {
+        var ri = getVisibleInfo(clipRects[i]);
+        if (ri.left < firstInfo.right && ri.right > firstInfo.left &&
+            ri.top > firstInfo.bottom && ri.bottom < firstInfo.top) {
+            overlappingRects.push(clipRects[i]);
+        }
+    }
+    if (overlappingRects.length === 0) return "Error: No clip rects overlap the first image.";
+
+    if (mode === "column") {
+        overlappingRects.sort(function (a, b) { return getVisibleInfo(a).left - getVisibleInfo(b).left; });
+    } else {
+        overlappingRects.sort(function (a, b) { return getVisibleInfo(b).top - getVisibleInfo(a).top; });
+    }
+
+    var rectOffsets = [];
+    for (var i = 0; i < overlappingRects.length; i++) {
+        var ri = getVisibleInfo(overlappingRects[i]);
+        rectOffsets.push({
+            dx: ri.left - firstInfo.left,
+            dy: ri.top - firstInfo.top,
+            w: ri.width,
+            h: ri.height
+        });
+    }
+
+    var gapPt = mmToPoints(gapMm);
+    var numImgs = sortedImages.length;
+    var numRects = overlappingRects.length;
+
+    var resultStartX, resultStartY;
+    if (mode === "column") {
+        var rightMost = -Infinity;
+        for (var i = 0; i < sortedInfos.length; i++) {
+            if (sortedInfos[i].right > rightMost) rightMost = sortedInfos[i].right;
+        }
+        resultStartX = rightMost + gapPt;
+        resultStartY = sortedInfos[0].top;
+    } else {
+        resultStartX = sortedInfos[0].left;
+        var bottomMost = Infinity;
+        for (var i = 0; i < sortedInfos.length; i++) {
+            if (sortedInfos[i].bottom < bottomMost) bottomMost = sortedInfos[i].bottom;
+        }
+        resultStartY = bottomMost - gapPt;
+    }
+
+    var clipGroups = [];
+    for (var r = 0; r < numRects; r++) {
+        clipGroups[r] = [];
+        for (var im = 0; im < numImgs; im++) {
+            var dupImg = sortedImages[im].duplicate();
+            var off = rectOffsets[r];
+            var clipLeft = sortedInfos[im].left + off.dx;
+            var clipTop = sortedInfos[im].top + off.dy;
+            var clipPath = doc.pathItems.rectangle(clipTop, clipLeft, off.w, off.h);
+            clipPath.filled = false;
+            clipPath.stroked = false;
+
+            var grp = doc.groupItems.add();
+            dupImg.move(grp, ElementPlacement.PLACEATEND);
+            clipPath.move(grp, ElementPlacement.PLACEATBEGINNING);
+            clipPath.clipping = true;
+            grp.clipped = true;
+
+            if (mode === "column") {
+                scaleItemToVisibleHeight(grp, refH);
+            } else {
+                scaleItemToVisibleWidth(grp, refW);
+            }
+            clipGroups[r][im] = grp;
+        }
+    }
+
+    var colWidths = [];
+    for (var r = 0; r < numRects; r++) {
+        var maxW = 0;
+        for (var im = 0; im < numImgs; im++) {
+            var gi = getVisibleInfo(clipGroups[r][im]);
+            if (gi.width > maxW) maxW = gi.width;
+        }
+        colWidths.push(maxW);
+    }
+    var rowHeights = [];
+    for (var im = 0; im < numImgs; im++) {
+        var maxH = 0;
+        for (var r = 0; r < numRects; r++) {
+            var gi = getVisibleInfo(clipGroups[r][im]);
+            if (gi.height > maxH) maxH = gi.height;
+        }
+        rowHeights.push(maxH);
+    }
+
+    if (mode === "column") {
+        var cx = resultStartX;
+        for (var r = 0; r < numRects; r++) {
+            var cy = resultStartY;
+            for (var im = 0; im < numImgs; im++) {
+                moveItemTopLeftTo(clipGroups[r][im], cx, cy);
+                cy -= rowHeights[im] + gapPt;
+            }
+            cx += colWidths[r] + gapPt;
+        }
+    } else {
+        var cy = resultStartY;
+        for (var im = 0; im < numImgs; im++) {
+            var cx = resultStartX;
+            for (var r = 0; r < numRects; r++) {
+                moveItemTopLeftTo(clipGroups[r][im], cx, cy);
+                cx += colWidths[r] + gapPt;
+            }
+            cy -= rowHeights[im] + gapPt;
+        }
+    }
+
+    // Copy rects to non-first images, preserving each rect's style
+    var imageRects = [];
+    imageRects[0] = overlappingRects.slice();
+    for (var im = 1; im < numImgs; im++) {
+        imageRects[im] = [];
+        for (var r = 0; r < numRects; r++) {
+            var off = rectOffsets[r];
+            var rectLeft = sortedInfos[im].left + off.dx;
+            var rectTop = sortedInfos[im].top + off.dy;
+            var newRect = doc.pathItems.rectangle(rectTop, rectLeft, off.w, off.h);
+            newRect.filled = false;
+            newRect.stroked = true;
+            // Preserve original rect's stroke color and width
+            try { newRect.strokeColor = overlappingRects[r].strokeColor; } catch (e) {}
+            try { newRect.strokeWidth = overlappingRects[r].strokeWidth; } catch (e) {}
+            imageRects[im].push(newRect);
+        }
+    }
+
+    // Group each image with its rects
+    for (var im = 0; im < numImgs; im++) {
+        var grp = doc.groupItems.add();
+        sortedImages[im].move(grp, ElementPlacement.PLACEATEND);
+        for (var r = 0; r < imageRects[im].length; r++) {
+            imageRects[im][r].move(grp, ElementPlacement.PLACEATBEGINNING);
+        }
+    }
+
+    return "Success";
+}


### PR DESCRIPTION
## Summary

- **Format Clip Rect**: Preset system for formatting selected rectangles with customizable color and stroke width. Default presets include Red 1pt, Blue 1pt, Green 1pt, Black 0.5pt. Users can add/delete presets (persisted in localStorage).
- **Array Clip**: Auto-detects column/row layout from selected images, finds clip rectangles overlapping the first image, creates clipped copies of all images, scales them proportionally, and arranges results to the right (column) or below (row). Copies clip rects to all other images and groups each image with its rects.

## Usage

1. Draw rectangles over an image with the Rectangle tool (M)
2. Select them → click **Apply** in Format Clip Rect section
3. Select all images + clip rects → click **Array Clip**

## Files changed

- `jsx/arrange.jsx` — Added `formatClipRect(color, width)` and `arrayClip(gapMm)` functions
- `client/index.html` — Added "Array Clip" tab with preset management UI and clip controls
- `host/index.jsx` — Added preset system (localStorage), handlers, event listeners

## Test plan

- [x] Format rectangles with different presets (color, width)
- [x] Add/delete custom presets
- [x] 1 image + 1 clip rect → generates 1 clip to the right
- [x] 3 images column + 2 clip rects → generates 6 clips in 2 columns to the right
- [x] 3 images row + 2 clip rects → generates 6 clips in 2 rows below
- [x] Mixed color/width rects preserved when copied to other images
- [x] Each original image grouped with its rects
- [x] Original images unmodified (clips use duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)